### PR TITLE
backend cache generation moved to back end, to avoid looped querying

### DIFF
--- a/pokemon-app/src/App.js
+++ b/pokemon-app/src/App.js
@@ -1,57 +1,40 @@
 import React from 'react';
 import './App.css';
 import PokemonHeader from './components/PokemonHeader'
-import PokemonCard from './components/PokemonCards';
 import SearchBar from './components/SearchBar';
 import generateCache from './components/GenerateCache';
+import LoginButton from './components/LoginButton';
+import LogoutButton from './components/LogoutButton';
+import CardContainer from './components/CardContainer';
 import getPokemonObjs from './components/GetPokemonObjs';
 import getPokemonNames from './components/GetPokemonNames';
-// const generateCache =  require('./components/GenerateCache');
-// const getPokemonObjs = require('./components/GetPokemonObjs');
-// const getPokemonNames = require('./components/GetPokemonNames');
 
 class App extends React.Component {
-
   constructor(props) {
     super(props); 
     this.state = {
       pokemonNameArr : [],
       pokemonObjArr: [],
-      cacheGenerated: false,
     }
-}
-
-  componentDidMount = async () => {
-    generateCache();
-    this.setState({
-      cacheGenerated: true,
-    })
   }
 
-  getPokemonCards = async () => {
-    if(this.state.cacheGenerated) {
-      let pokemonObjsData = await getPokemonObjs();
-      let pokemonNamesData = await getPokemonNames();
-
-      this.setState({
-        pokemonObjArr : pokemonObjsData,
-        pokeNameArr : pokemonNamesData,
-      })
-    } 
+  componentDidMount = async () =>{
+    console.log('pre: ' + this.state.pokemonObjArr);
+    this.setState({
+      pokemonObjArr : await getPokemonObjs(),
+      pokemonNameArr : await getPokemonNames()
+    })
+    console.log('post: ' + this.state.pokemonObjArr);
   }
 
   render() {
-
-    {this.getPokemonCards()}
-
     return (
       <>
         <PokemonHeader/>
         <SearchBar pokemonNames={this.state.pokemonNameArr}/>
-          {
-            this.state.pokemonObjArr ? this.state.pokemonObjArr.map(pokemon => 
-            <PokemonCard name={pokemon.name} id={pokemon.id} description={pokemon.description} moves={pokemon.moves} sprites={pokemon.sprites} stats={pokemon.stats} types={pokemon.types}/> ) : <></>
-          }
+        <LoginButton></LoginButton>
+        <LogoutButton></LogoutButton>
+        <CardContainer pokemonArr={this.state.pokemonObjArr}></CardContainer>
         <button id='test-button' onClick={this.getPokemon151}>Submit</button>
       </>
     );

--- a/pokemon-app/src/components/CardContainer.js
+++ b/pokemon-app/src/components/CardContainer.js
@@ -1,0 +1,32 @@
+import React from "react";
+import PokemonCard from "./PokemonCards";
+
+class CardContainer extends React.Component {
+    constructor(props) {
+        super(props); 
+        this.state = {
+
+        }
+    }
+
+    render() {
+        return (
+            <>
+                {
+                    this.props.pokemonArr.length > 0 ? this.props.pokemonArr.map(pokemon => 
+                    <PokemonCard 
+                    name={pokemon.name} 
+                    id={pokemon.id} 
+                    description={pokemon.description} 
+                    moves={pokemon.moves} 
+                    sprites={pokemon.sprites} 
+                    stats={pokemon.stats} 
+                    types={pokemon.types}
+                    />) : <></>
+                }
+            </>
+        );
+    }
+}
+
+export default CardContainer;

--- a/pokemon-app/src/components/GenerateCache.js
+++ b/pokemon-app/src/components/GenerateCache.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 //require('dotenv').config();
 
 async function generateCache() {
-    await axios.get(process.env.REACT_APP_BACK_END);
+    return await axios.get(process.env.REACT_APP_BACK_END);
 };
 
 export default generateCache;

--- a/pokemon-app/src/components/LogoutButton.js
+++ b/pokemon-app/src/components/LogoutButton.js
@@ -1,0 +1,14 @@
+import { useAuth0 } from "@auth0/auth0-react";
+import React from "react";
+
+const LogoutButton = () => {
+  const { logout } = useAuth0();
+
+  return (
+    <button onClick={() => logout({ returnTo: window.location.origin })}>
+      Log Out
+    </button>
+  );
+};
+
+export default LogoutButton;


### PR DESCRIPTION
backend cache generation moved to back end, to avoid looped call of querying function. Due to the call being within the component renderer,  console logs revealed that the function was being called on tick endlessly. To unnecessary function calls, cache generation was moved to the backend, where information gathering and filtering can be done on server start, instead of at front end start